### PR TITLE
Added PHP date.timezone note for 6.6 release. Refs #3016 #3068

### DIFF
--- a/administrator-manual/en/release_notes.rst
+++ b/administrator-manual/en/release_notes.rst
@@ -43,7 +43,8 @@ Changes
 * If ``nethserver-mail-filter`` and ``nethserver-firewall-base`` are both installed 
   (gateway mode), port 25 is blocked from green and blue zones. See :ref:`email-port25`.
 
-* The ``php/DateTimezone`` default prop value changed from ``UTC`` to
+* The ``php/DateTimezone`` is now **deprecated** and will be removed
+  on the next release. The default prop value changed from ``UTC`` to
   the empty string. When that prop is set to empty string the actual
   PHP ``date.timezone`` INI setting is inherited from the system
   default ``TimeZone``.  Depending on existing PHP applications and

--- a/administrator-manual/en/release_notes.rst
+++ b/administrator-manual/en/release_notes.rst
@@ -43,18 +43,10 @@ Changes
 * If ``nethserver-mail-filter`` and ``nethserver-firewall-base`` are both installed 
   (gateway mode), port 25 is blocked from green and blue zones. See :ref:`email-port25`.
 
-* The ``php/DateTimezone`` is now **deprecated** and will be removed
-  on the next release. The default prop value changed from ``UTC`` to
-  the empty string. When that prop is set to empty string the actual
-  PHP ``date.timezone`` INI setting is inherited from the system
-  default ``TimeZone``.  Depending on existing PHP applications and
-  current system ``TimeZone``, it should be safe to adopt the new
-  default value: ::
-
-    config setprop php DateTimezone ''
-    expand-template /etc/php.ini
-
-  Then restart ``httpd`` and other dependant services accordingly.
+* The ``php/DateTimezone`` prop value is now controlled from
+  :guilabel:`Date and time` page, that already sets the system time zone.
+  If the system-wide value is not valid for the PHP INI
+  ``date.timezone`` parameter, the default ``UTC`` is set instead.
 
 Upgrading from 6.5
 ==================
@@ -73,4 +65,16 @@ Then, start the upgrade: ::
 
   yum -c http://pulp.nethserver.org/nethserver/nethserver-6.6.conf update
 
+Things that can be tweaked:
+
+* Upgrade the default PHP timezone (``date.timezone`` INI setting)
+  from system default:
+  
+  1. In :guilabel:`Date and time` page change the :guilabel:`Timezone`
+     to a temporary value and click :guilabel:`Submit` button.
+
+  2. Set the :guilabel:`Timezone` to the original value and click
+     :guilabel:`Submit` again.
+  	      
 Finally, reboot the system.
+

--- a/administrator-manual/en/release_notes.rst
+++ b/administrator-manual/en/release_notes.rst
@@ -43,6 +43,18 @@ Changes
 * If ``nethserver-mail-filter`` and ``nethserver-firewall-base`` are both installed 
   (gateway mode), port 25 is blocked from green and blue zones. See :ref:`email-port25`.
 
+* The ``php/DateTimezone`` default prop value changed from ``UTC`` to
+  the empty string. When that prop is set to empty string the actual
+  PHP ``date.timezone`` INI setting is inherited from the system
+  default ``TimeZone``.  Depending on existing PHP applications and
+  current system ``TimeZone``, it should be safe to adopt the new
+  default value: ::
+
+    config setprop php DateTimezone ''
+    expand-template /etc/php.ini
+
+  Then restart ``httpd`` and other dependant services accordingly.
+
 Upgrading from 6.5
 ==================
 

--- a/administrator-manual/it/release_notes.rst
+++ b/administrator-manual/it/release_notes.rst
@@ -44,12 +44,13 @@ Cambiamenti
   sono installati (modalità gateway), la porta 25 è bloccata dalle reti blue e green.
   Vedi :ref:`email-port25`.
 
-* Il valore di default della prop ``php/DateTimezone`` è cambiato da
-  ``UTC`` alla stringa vuota. Quando questa prop è una stringa vuota
-  il valore INI di PHP ``date.timezone`` è ereditato dal default
-  ``TimeZone`` di sistema.  A seconda delle applicazioni PHP
-  installate e dal valore di ``TimeZone`` dovrebbe essere accettabile
-  l'adozione del nuovo valore di default: ::
+* La prop ``php/DateTimezone`` è ora **deprecata** e sarà rimossa
+  nella prossima release. Il valore di default è cambiato da ``UTC``
+  alla stringa vuota. Quando questa prop è una stringa vuota il valore
+  INI di PHP ``date.timezone`` è ereditato dal default ``TimeZone`` di
+  sistema.  A seconda delle applicazioni PHP installate e dal valore
+  di ``TimeZone`` dovrebbe essere accettabile l'adozione del nuovo
+  valore di default: ::
 
     config setprop php DateTimezone ''
     expand-template /etc/php.ini

--- a/administrator-manual/it/release_notes.rst
+++ b/administrator-manual/it/release_notes.rst
@@ -44,6 +44,19 @@ Cambiamenti
   sono installati (modalità gateway), la porta 25 è bloccata dalle reti blue e green.
   Vedi :ref:`email-port25`.
 
+* Il valore di default della prop ``php/DateTimezone`` è cambiato da
+  ``UTC`` alla stringa vuota. Quando questa prop è una stringa vuota
+  il valore INI di PHP ``date.timezone`` è ereditato dal default
+  ``TimeZone`` di sistema.  A seconda delle applicazioni PHP
+  installate e dal valore di ``TimeZone`` dovrebbe essere accettabile
+  l'adozione del nuovo valore di default: ::
+
+    config setprop php DateTimezone ''
+    expand-template /etc/php.ini
+
+  Quindi riavviare ``httpd`` e gli altri servizi dipendenti da ``php.ini``.
+
+
 
 Aggiornamento da 6.5
 ====================

--- a/administrator-manual/it/release_notes.rst
+++ b/administrator-manual/it/release_notes.rst
@@ -44,20 +44,11 @@ Cambiamenti
   sono installati (modalità gateway), la porta 25 è bloccata dalle reti blue e green.
   Vedi :ref:`email-port25`.
 
-* La prop ``php/DateTimezone`` è ora **deprecata** e sarà rimossa
-  nella prossima release. Il valore di default è cambiato da ``UTC``
-  alla stringa vuota. Quando questa prop è una stringa vuota il valore
-  INI di PHP ``date.timezone`` è ereditato dal default ``TimeZone`` di
-  sistema.  A seconda delle applicazioni PHP installate e dal valore
-  di ``TimeZone`` dovrebbe essere accettabile l'adozione del nuovo
-  valore di default: ::
-
-    config setprop php DateTimezone ''
-    expand-template /etc/php.ini
-
-  Quindi riavviare ``httpd`` e gli altri servizi dipendenti da ``php.ini``.
-
-
+* Il valore della prop ``php/DateTimezone`` è ora controllato dalla
+  pagina :guilabel:`Data e ora`, che già imposta il fuso orario del
+  sistema. Se il valore del sistema non può essere applicato al
+  parametro PHP INI ``date.timezone``, viene considerato il valore di
+  default ``UTC``.
 
 Aggiornamento da 6.5
 ====================
@@ -76,5 +67,17 @@ Quindi, avviare l'aggiornamento: ::
   
   yum -c http://pulp.nethserver.org/nethserver/nethserver-6.6.conf update
 
+Cose che possono essere aggiustate:
+
+* Aggiornare il fuso orario di default di PHP (``date.timezone`` INI
+  setting) dal valore di default del sistema:
+
+  1. Nella pagina :guilabel:`Data e ora` cambiare :guilabel:`Fuso
+     orario` in un valore temporaneo e premere il pulsante
+     :guilabel:`Salva`.
+
+  2. Impostare il valore di :guilabel:`Fuso orario` a quello originale
+     e premere di nuovo :guilabel:`Salva`.
+  
 Al termine, riavviare il sistema.
 


### PR DESCRIPTION
I'd like to add also a deprecation warning for ``php/DateTimezone`` prop. What do you think?